### PR TITLE
CLK Pin 3 goes to Arduino A5, not A6

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The pinout should be:
 
     1	- SPKR - Arduino Pin A2
     2	- MIC  - Arduino Pin D3
-    3	- CLK  - Arduino Pin A5
-    4	- nCS  - Arduino Pin A1
-    5	- DAT  - Arduino Pin A4
+    3	- CLK/SCLK  - Arduino Pin A5
+    4	- DAT/SDIO  - Arduino Pin A4
+    5	- nCS/nSEN  - Arduino Pin A1
     6	- GND  - Arduino Pin GND
     7	- VCC  - Arduino Pin 5V
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The pinout should be:
 
     1	- SPKR - Arduino Pin A2
     2	- MIC  - Arduino Pin D3
-    3	- CLK  - Arduino Pin A6
+    3	- CLK  - Arduino Pin A5
     4	- nCS  - Arduino Pin A1
     5	- DAT  - Arduino Pin A4
     6	- GND  - Arduino Pin GND


### PR DESCRIPTION
Probably was a typo, fixed.  Bad joo joo for noobs when there's a pin error in README.md :-)